### PR TITLE
feature: Double underscore to dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ The output is provided on standard output and without any additional new-line, a
 
 Each environment variable is transformed as follows:
 
- - remove the trailing prefix (if specified)
- - trasform all the "__" into `-`
- - trasform all the `_` characters into `.`
+- remove the trailing prefix (if specified)
+- trasform all the "__" into `-`
+- trasform all the `_` characters into `.`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The output is provided on standard output and without any additional new-line, a
 Each environment variable is transformed as follows:
 
  - remove the trailing prefix (if specified)
+ - trasform all the "__" into `-`
  - trasform all the `_` characters into `.`
 
 ## Usage

--- a/spec/java_properties_spec.cr
+++ b/spec/java_properties_spec.cr
@@ -32,6 +32,15 @@ it "should properly propagate escaped multi string java properties" do
   exit_value.should eq(0)
 end
 
+it "should properly translate double underscores in single dash" do
+  args = DEFAULT_ARGS.clone
+  args << %(export CONFIG_my__key3=myvalue && sh -c "java $(bin/env2props -p CONFIG_) spec.CheckProperties")
+  exit_value, output = run_cmd(CMD, args)
+
+  output.includes?("my-key3:myvalue").should eq(true)
+  exit_value.should eq(0)
+end
+
 it "should properly inject multiple java properties" do
   args = DEFAULT_ARGS.clone
   args << %(export CONFIG_mykey11=1 && export CONFIG_mykey22=2 && java $(bin/env2props -p CONFIG_) spec.CheckProperties)

--- a/src/env2props.cr
+++ b/src/env2props.cr
@@ -23,7 +23,8 @@ props = String.build do |props|
 
     key = k
       .lchop(prefix)
-      .gsub("_", ".") # all underscores to dots
+      .gsub("__", "-") # double underscore to dash
+      .gsub("_", ".")  # all underscores to dots
 
     # given https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html#load-java.io.InputStream-
     encoding = "ISO8859-1"


### PR DESCRIPTION
as agreed:
the point here is that a double underscore will translate to a double dot that is not used in HOCON configuration.
That given dash is a valid character in java props and not in env vars, so here we are.

cc @rtfpessoa 