### PR TITLE
feature: Create version badge endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,12 @@ jobs:
             echo -n $(cat .version) >> version.json
             echo -n '"}' >> version.json
       - store_artifacts:
+          path: CHANGELOG.md
+          destination: CHANGELOG.md
+      - store_artifacts:
+          path: changelog.html
+          destination: changelog.html
+      - store_artifacts:
           path: version.json
           destination: version.json
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,6 @@ workflows:
       - changelog_html:
           requires:
             - changelog
-      - version_badge:
+      - version_badge: # this has to be always the last scheduled job ...
           requires:
             - changelog_html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ workflows:
               only:
               - master
           context: CodacyAWS
-      - changelog
+      - changelog:
           requires:
             - test
       - changelog_html:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,22 @@ jobs:
           path: changelog.html
           destination: changelog.html
 
+  version_badge:
+    <<: *default_machine_job
+    working_directory: ~/workdir
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Create version badge endpoint
+          command: |
+            echo -n '{"schemaVersion": 1, "label": "version", "color": "blue", "message":"' > version.json
+            echo -n $(cat .version) >> version.json
+            echo -n '"}' >> version.json
+      - store_artifacts:
+          path: version.json
+          destination: version.json
+
 workflows:
   version: 2
   publish:
@@ -139,3 +155,6 @@ workflows:
       - changelog_html:
           requires:
             - changelog
+      - version_badge:
+          requires:
+            - changelog_html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,8 +87,10 @@ jobs:
       - image: biig/auto-changelog:1.11.0
     working_directory: ~/workdir
     steps:
-      - attach_workspace:
-          at: ~/
+      - checkout
+      - run:
+          name: Checkout master branch
+          command: git checkout master
       - run:
           name: Generate Changelog
           command: auto-changelog
@@ -149,9 +151,7 @@ workflows:
               only:
               - master
           context: CodacyAWS
-      - changelog:
-          requires:
-            - publish-github-release
+      - changelog
       - changelog_html:
           requires:
             - changelog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,10 @@ jobs:
       - run:
           name: Generate Changelog Html
           command: pandoc -f markdown -t html5 -o changelog.html CHANGELOG.md -c changelog/pandoc.css --self-contained
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - workdir/*
 
   version_badge:
     <<: *default_machine_job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,9 @@ workflows:
               only:
               - master
           context: CodacyAWS
+
+  documentation:
+    jobs:
       - changelog
       - changelog_html:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,10 +155,9 @@ workflows:
               only:
               - master
           context: CodacyAWS
-
-  documentation:
-    jobs:
       - changelog
+          requires:
+            - test
       - changelog_html:
           requires:
             - changelog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,12 +109,6 @@ jobs:
       - run:
           name: Generate Changelog Html
           command: pandoc -f markdown -t html5 -o changelog.html CHANGELOG.md -c changelog/pandoc.css --self-contained
-      - store_artifacts:
-          path: CHANGELOG.md
-          destination: CHANGELOG.md
-      - store_artifacts:
-          path: changelog.html
-          destination: changelog.html
 
   version_badge:
     <<: *default_machine_job

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/c811f6b557ee4e44ad373084015ba0b3)](https://www.codacy.com/app/Codacy/env2props?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=codacy/env2props&amp;utm_campaign=Badge_Grade)
 [![CircleCI](https://circleci.com/gh/codacy/env2props.svg?style=svg)](https://circleci.com/gh/codacy/env2props)
-[![](https://img.shields.io/github/release/codacy/env2props.svg)](https://github.com/codacy/env2props/releases)
+[![](https://img.shields.io/endpoint.svg?url=https://circleci.com/api/v1.1/project/github/codacy/env2props/latest/artifacts/0/version.json)](https://github.com/codacy/env2props/releases)
 
 
 


### PR DESCRIPTION
This example show how we can leverage circle ci artifacts for having version badges in a standard way (e.g. applicable also to private repository etc. etc.)